### PR TITLE
Feature: purchase takes place in 1 tx

### DIFF
--- a/contracts/FishProxy.sol
+++ b/contracts/FishProxy.sol
@@ -51,7 +51,7 @@ contract FishProxy is SharkProxy {
   /**
    * @dev _addr is address for the nutz satelite
    */
-  function purchase(address _addr) payable {
+  function purchase(address _addr) payable onlyOwner {
     // allow 1 tx purchase only if unlocked
     assert(lockAddr == address(0));
     bytes memory empty;

--- a/contracts/SharkProxy.sol
+++ b/contracts/SharkProxy.sol
@@ -33,7 +33,7 @@ contract SharkProxy is Ownable {
   /**
    * @dev _addr is address for the nutz satelite
    */
-  function purchase(address _addr) payable {
+  function purchase(address _addr) payable onlyOwner {
     bytes memory empty;
     forward(_addr, msg.value, empty);
   }


### PR DESCRIPTION
Made a simple payable function `purchase` to the proxy contract that forwards the call to the nutz contract. 
Gas calculations - Increased deployment cost           - 0.06 USD
                              Saved during EACH purchase      ~ 0.05 USD
Gas costs for deployment is offset during purchase.

Test case in https://github.com/acebusters/economy/blob/test/feature/1txPurchase/test/nutz.js#L86-L102